### PR TITLE
Update date handling in FixedExpenses logic and improve UI elements

### DIFF
--- a/src/Valt.UI/Lang/language.Designer.cs
+++ b/src/Valt.UI/Lang/language.Designer.cs
@@ -1238,5 +1238,17 @@ namespace Valt.UI.Lang {
                 return ResourceManager.GetString("About.Title", resourceCulture);
             }
         }
+        
+        public static string About_Tip {
+            get {
+                return ResourceManager.GetString("About.Tip", resourceCulture);
+            }
+        }
+        
+        public static string Settings_RequiresRestart {
+            get {
+                return ResourceManager.GetString("Settings.RequiresRestart", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Valt.UI/Lang/language.pt-BR.resx
+++ b/src/Valt.UI/Lang/language.pt-BR.resx
@@ -615,4 +615,10 @@
     <data name="About.Title" xml:space="preserve">
         <value>Sobre</value>
     </data>
+    <data name="About.Tip" xml:space="preserve">
+        <value>Se você gosta do app, me manda uns sats:</value>
+    </data>
+    <data name="Settings.RequiresRestart" xml:space="preserve">
+        <value>(requer reinicialização)</value>
+    </data>
 </root>

--- a/src/Valt.UI/Lang/language.resx
+++ b/src/Valt.UI/Lang/language.resx
@@ -620,4 +620,10 @@
     <data name="About.Title" xml:space="preserve">
         <value>About</value>
     </data>
+    <data name="About.Tip" xml:space="preserve">
+        <value>If you like the app, send me some sats:</value>
+    </data>
+    <data name="Settings.RequiresRestart" xml:space="preserve">
+        <value>(requires restart)</value>
+    </data>
 </root>

--- a/src/Valt.UI/Views/Main/Modals/About/AboutView.axaml
+++ b/src/Valt.UI/Views/Main/Modals/About/AboutView.axaml
@@ -18,6 +18,11 @@
     <Design.DataContext>
         <about:AboutViewModel />
     </Design.DataContext>
+    <Window.Styles>
+        <Style Selector="Window">
+            <Setter Property="FontFamily" Value="Mono"></Setter>
+        </Style>
+    </Window.Styles>
     <Border>
         <StackPanel Orientation="Vertical">
             <userControls:CustomTitleBar Title="{x:Static local:language.About_Title}"
@@ -26,24 +31,25 @@
             <Grid Margin="20" RowDefinitions="200, *">
                 <Grid Grid.Row="0" ColumnDefinitions="128, *">
                     <Image Grid.Column="0" Source="/Assets/valt-logo.png" Width="128" Height="138" />
-                    <TextBlock Margin="20, 0, 0, 0" Grid.Column="1" TextWrapping="Wrap">
-                        <TextBlock Text="VALT" FontFamily="Arial" FontSize="48"></TextBlock>
+                    <TextBlock Margin="20, 0, 0, 0" Grid.Column="1" FontSize="12" TextWrapping="Wrap">
+                        <TextBlock Text="VALT" FontSize="48"></TextBlock>
                         <TextBlock Text="{Binding AppVersion}" FontSize="12" Margin="0, -24, 0, 0" />
+                        <LineBreak />
                         <LineBreak />
                         <TextBlock Text="Created by BtcDoomGuy"></TextBlock>
                         <LineBreak />
                         <LineBreak />
-                        <TextBlock Text="Find me on X: @BtcChicoFatal"></TextBlock>
+                        <HyperlinkButton NavigateUri="https://x.com/btcchicofatal">@BtcChicoFatal</HyperlinkButton>
                         <LineBreak />
                         <LineBreak />
-                        <TextBlock Text="GitHub: https://github.com/btcdoomguy/valt/"></TextBlock>
+                        <HyperlinkButton NavigateUri="https://github.com/btcdoomguy/valt/">https://github.com/btcdoomguy/valt/</HyperlinkButton>
                     </TextBlock>
                 </Grid>
                 <StackPanel Grid.Row="1">
-                    <TextBlock TextWrapping="Wrap">
-                        <TextBlock>If you like the app, send me a coffee:</TextBlock>
+                    <TextBlock FontSize="12" TextWrapping="Wrap">
+                        <TextBlock Text="{x:Static local:language.About_Tip}"></TextBlock>
                     </TextBlock>
-                    <TextBox Text="{Binding DonationAddresses}" IsReadOnly="True" Height="100" AcceptsReturn="True"
+                    <TextBox Text="{Binding DonationAddresses}" FontFamily="Mono" IsReadOnly="True" Height="100" AcceptsReturn="True"
                              TextWrapping="NoWrap" FontSize="10">
                     </TextBox>
                 </StackPanel>

--- a/src/Valt.UI/Views/Main/Modals/Settings/SettingsView.axaml
+++ b/src/Valt.UI/Views/Main/Modals/Settings/SettingsView.axaml
@@ -10,10 +10,10 @@
         x:DataType="settings1:SettingsViewModel"
         Title="{x:Static local:language.Settings_Title}"
         WindowStartupLocation="CenterOwner"
-        d:DesignWidth="450"
-        d:DesignHeight="400"
-        MaxWidth="450"
-        MaxHeight="400"
+        d:DesignWidth="550"
+        d:DesignHeight="420"
+        MaxWidth="550"
+        MaxHeight="420"
         ExtendClientAreaToDecorationsHint="True"
         SystemDecorations="None"
         ExtendClientAreaTitleBarHeightHint="0">
@@ -25,40 +25,52 @@
             <userControls:CustomTitleBar Title="{x:Static local:language.Settings_Title}"
                                          TitleBarPressed="CustomTitleBarButtonPressed"
                                          CloseClick="CustomTitleBarCloseClicked" />
-            <Border Classes="form-fields-area" Height="320">
+            <Border Classes="form-fields-area" Height="340">
                 <StackPanel Orientation="Vertical" Spacing="20">
                     <DockPanel>
-                        <TextBlock Width="150" TextAlignment="Right" Margin="0,0,5,0"
+                        <TextBlock Width="220" TextAlignment="Right" Margin="0,0,5,0"
                                    VerticalAlignment="Center"
                                    Text="{x:Static local:language.Settings_MainFiatCurrency}" TextWrapping="Wrap" />
                         <ComboBox ItemsSource="{Binding AvailableFiatCurrencies}"
-                                  SelectedItem="{Binding MainFiatCurrency}" Width="200" />
-
+                                  SelectedItem="{Binding MainFiatCurrency}" Width="100" />
                     </DockPanel>
                     <DockPanel>
-                        <TextBlock Width="150" TextAlignment="Right" Margin="0,0,5,0"
+                        <TextBlock Width="220" TextAlignment="Right" Margin="0,0,5,0"
                                    VerticalAlignment="Center"
                                    Text="{x:Static local:language.Settings_Culture}" TextWrapping="Wrap" />
-                        <ComboBox ItemsSource="{Binding Cultures}"
-                                  DisplayMemberBinding="{Binding Text}"
-                                  SelectedValueBinding="{Binding Value}"
-                                  SelectedValue="{Binding CurrentCulture}" Width="200" />
+                        <StackPanel Orientation="Vertical">
+                            <ComboBox ItemsSource="{Binding Cultures}"
+                                      DisplayMemberBinding="{Binding Text}"
+                                      SelectedValueBinding="{Binding Value}"
+                                      SelectedValue="{Binding CurrentCulture}" Width="200" />
+                            
+                            <TextBlock FontStyle="Italic" Text="{x:Static local:language.Settings_RequiresRestart}" />
+                        </StackPanel>
                     </DockPanel>
                     <DockPanel>
-                        <TextBlock Width="150" TextAlignment="Right" Margin="0,0,5,0"
+                        <TextBlock Width="220" TextAlignment="Right" Margin="0,0,5,0"
                                    VerticalAlignment="Center"
                                    Text="{x:Static local:language.Settings_ShowHiddenAccounts}" TextWrapping="Wrap" />
                         <CheckBox IsChecked="{Binding ShowHiddenAccounts}"></CheckBox>
                     </DockPanel>
-                    <Button HorizontalAlignment="Center" Classes="transparent link" Command="{Binding ClearAccountCacheCommand}" Content="{x:Static local:language.Settings_ClearAccountTotalsCache}" />
-                    <Button HorizontalAlignment="Center" Classes="transparent link" Command="{Binding ProcessTransactionTermCacheCommand}"  Content="{x:Static local:language.Settings_ClearTransactionTermCache}" />
-                    <Button HorizontalAlignment="Center" Classes="transparent link" Command="{Binding ChangeDatabasePasswordCommand}"  Content="{x:Static local:language.Settings_ChangeDatabasePassword}" />
+                    <Button HorizontalAlignment="Center" Classes="transparent link"
+                            Command="{Binding ClearAccountCacheCommand}"
+                            Content="{x:Static local:language.Settings_ClearAccountTotalsCache}" />
+                    <Button HorizontalAlignment="Center" Classes="transparent link"
+                            Command="{Binding ProcessTransactionTermCacheCommand}"
+                            Content="{x:Static local:language.Settings_ClearTransactionTermCache}" />
+                    <Button HorizontalAlignment="Center" Classes="transparent link"
+                            Command="{Binding ChangeDatabasePasswordCommand}"
+                            Content="{x:Static local:language.Settings_ChangeDatabasePassword}" />
                 </StackPanel>
             </Border>
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="10"
                         Margin="0, 0, 0, 0">
-                <Button Width="100" Content="{x:Static local:language.OkButton}" HorizontalContentAlignment="Center" Command="{Binding OkCommand}"></Button>
-                <Button Width="100" Content="{x:Static local:language.CancelButton}" HorizontalContentAlignment="Center"
+                <Button Width="100" Content="{x:Static local:language.OkButton}" HorizontalContentAlignment="Center"
+                        Command="{Binding OkCommand}">
+                </Button>
+                <Button Width="100" Content="{x:Static local:language.CancelButton}"
+                        HorizontalContentAlignment="Center"
                         Command="{Binding CancelCommand}">
                 </Button>
             </StackPanel>

--- a/src/Valt.UI/Views/Main/Tabs/Transactions/Models/FixedExpensesEntryViewModel.cs
+++ b/src/Valt.UI/Views/Main/Tabs/Transactions/Models/FixedExpensesEntryViewModel.cs
@@ -5,7 +5,7 @@ using Valt.Infra.Modules.Budget.FixedExpenses;
 
 namespace Valt.UI.Views.Main.Tabs.Transactions.Models;
 
-public class FixedExpensesEntryViewModel(FixedExpenseProviderEntry entry, int currentDay)
+public class FixedExpensesEntryViewModel(FixedExpenseProviderEntry entry, DateOnly currentDate)
 {
     public FixedExpenseProviderEntry Entry { get; } = entry;
     public string Id => Entry.Id;
@@ -31,7 +31,7 @@ public class FixedExpensesEntryViewModel(FixedExpenseProviderEntry entry, int cu
 
     public int Day => Entry.Day;
     
-    public bool IsLateOrCurrentDay => Day <= currentDay;
+    public bool IsLateOrCurrentDay => ReferenceDate <= currentDate;
 
     public SolidColorBrush CheckboxPaidColor =>
         Paid ? FixedExpenseListResources.PaidForeground : FixedExpenseListResources.DefaultForeground;

--- a/src/Valt.UI/Views/Main/Tabs/Transactions/TransactionsViewModel.cs
+++ b/src/Valt.UI/Views/Main/Tabs/Transactions/TransactionsViewModel.cs
@@ -131,7 +131,7 @@ public partial class TransactionsViewModel : ValtViewModel, IDisposable
 
         SelectedAccount = Accounts.FirstOrDefault();
 
-        var currentMockedDay = 10;
+        var currentMockedDay = new DateOnly(2025, 1, 10);
 
         FixedExpenseEntries =
         [
@@ -303,7 +303,7 @@ public partial class TransactionsViewModel : ValtViewModel, IDisposable
         FixedExpenseEntries.Clear();
         foreach (var fixedExpense in fixedExpenses)
         {
-            FixedExpenseEntries.Add(new FixedExpensesEntryViewModel(fixedExpense, _clock.GetCurrentLocalDate().Day));
+            FixedExpenseEntries.Add(new FixedExpensesEntryViewModel(fixedExpense, _clock.GetCurrentLocalDate()));
 
             if (fixedExpense.State != FixedExpenseRecordState.Empty)
                 continue;
@@ -455,7 +455,7 @@ public partial class TransactionsViewModel : ValtViewModel, IDisposable
 
     public FixedExpensesEntryViewModel? SelectedFixedExpense
     {
-        get =>  _filterState!.SelectedFixedExpense is not null ? new FixedExpensesEntryViewModel(_filterState!.SelectedFixedExpense, _clock.GetCurrentLocalDate().Day) : null;
+        get =>  _filterState!.SelectedFixedExpense is not null ? new FixedExpensesEntryViewModel(_filterState!.SelectedFixedExpense, _clock.GetCurrentLocalDate()) : null;
         set => _filterState!.SelectedFixedExpense = value?.Entry;
     }
 


### PR DESCRIPTION
Refactored `FixedExpensesEntryViewModel` to use `DateOnly` instead of integers for enhanced clarity and accuracy in date comparisons. Expanded the Settings modal with additional restart prompts for culture changes. Updated About modal with donation functionality, refined font styling, and introduced hyperlink buttons. Improved control dimensions and layout across Settings and About modals for better usability. Added new localized strings to language resources.