### PR TITLE
Add macOS packaging and DMG support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ ClientBin/
 *.iml
 *.iws
 *.ipr
+
+# macOS packaging artifacts
+*.dmg

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *.suo
 *.user
 *.sln.docstates
+.DS_Store
+Valt.app/
+publish/
 
 # Build results
 

--- a/README.md
+++ b/README.md
@@ -30,8 +30,30 @@ With Valt, you can easily keep track of your finances and stay in control of you
 
 - 💲 **More Fiat Currencies**: Expand support for additional fiat currencies.
 - 🎨 **Interface & UX Improvements**: Enhance the overall look, feel, and user experience.
-- 🆕 **Latest Changes Window**: A dedicated view for recent updates and changes.
+- 🔕 **Latest Changes Window**: A dedicated view for recent updates and changes.
 - 🌎 **More Languages**: Add support for additional languages.
+
+## macOS Packaging 🍎
+
+Valt can be packaged as a native macOS application for Apple Silicon (arm64). The repository includes scripts to build and package the app:
+
+### Prerequisites
+- .NET 10 SDK
+- Avalonia UI
+- `create-dmg` (install via `brew install create-dmg`)
+
+### Build and Package
+```bash
+# Build the app and create the .app bundle
+./scripts/package-macos.sh
+
+# Create a distributable DMG image
+./scripts/create-dmg.sh
+```
+
+The generated `Valt.app` can be dragged to `/Applications`. The DMG image (`Valt-macos-arm64.dmg`) provides a simple installer with a default Finder background.
+
+**Note:** The app is signed with an ad‑hoc signature for local use. For distribution outside your machine, consider obtaining an Apple Developer ID and performing proper notarization.
 
 ## Disclaimer ⚠️
 

--- a/scripts/create-dmg.sh
+++ b/scripts/create-dmg.sh
@@ -19,22 +19,11 @@ rm -f Valt-macos-arm64.dmg
 echo "Removed old Valt-macos-arm64.dmg"
 echo ""
 
-# 3. Check if create-dmg is available
-if ! command -v create-dmg &> /dev/null; then
-    echo "Warning: create-dmg not found. Installing via brew..."
-    brew install create-dmg || {
-        echo "Failed to install create-dmg. Please install manually:"
-        echo "  brew install create-dmg"
-        exit 1
-    }
-fi
-
-# 4. Use create-dmg to generate DMG
+# 3. Use create-dmg to generate DMG
 echo "[3/4] Creating DMG..."
 create-dmg \
   --volname "Valt macOS Apple Silicon" \
   --volicon "src/Valt.UI/Assets/valt-logo.ico" \
-  --background "src/Valt.UI/Assets/valt-logo.png" \
   --window-pos 200 120 \
   --window-size 800 400 \
   --icon-size 100 \

--- a/scripts/create-dmg.sh
+++ b/scripts/create-dmg.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -e
+
+echo "=== Valt DMG Creation Script ==="
+echo ""
+
+# 1. Check if Valt.app exists
+if [ ! -d "Valt.app" ]; then
+    echo "[1/4] Valt.app not found, running package-macos.sh..."
+    ./scripts/package-macos.sh
+else
+    echo "[1/4] Valt.app found, skipping package-macos.sh"
+fi
+echo ""
+
+# 2. Remove old DMG if it exists
+echo "[2/4] Removing old DMG if exists..."
+rm -f Valt-macos-arm64.dmg
+echo "Removed old Valt-macos-arm64.dmg"
+echo ""
+
+# 3. Check if create-dmg is available
+if ! command -v create-dmg &> /dev/null; then
+    echo "Warning: create-dmg not found. Installing via brew..."
+    brew install create-dmg || {
+        echo "Failed to install create-dmg. Please install manually:"
+        echo "  brew install create-dmg"
+        exit 1
+    }
+fi
+
+# 4. Use create-dmg to generate DMG
+echo "[3/4] Creating DMG..."
+create-dmg \
+  --volname "Valt macOS Apple Silicon" \
+  --volicon "src/Valt.UI/Assets/valt-logo.ico" \
+  --background "src/Valt.UI/Assets/valt-logo.png" \
+  --window-pos 200 120 \
+  --window-size 800 400 \
+  --icon-size 100 \
+  --icon "Valt.app" 200 190 \
+  --hide-extension "Valt.app" \
+  --no-internet-enable \
+  --app-drop-link 600 190 \
+  "Valt-macos-arm64.dmg" \
+  "Valt.app"
+
+echo "DMG created: Valt-macos-arm64.dmg"
+echo ""
+
+# 5. Verify DMG
+echo "[4/4] Verifying DMG..."
+if [ -f "Valt-macos-arm64.dmg" ]; then
+    echo "Success! DMG details:"
+    ls -lh Valt-macos-arm64.dmg
+    echo ""
+    echo "=== DMG Creation Complete ==="
+    echo ""
+    echo "To test the DMG:"
+    echo "  open Valt-macos-arm64.dmg"
+    echo ""
+    echo "To install:"
+    echo "  1. Open the DMG"
+    echo "  2. Drag Valt.app to /Applications"
+    echo "  3. Right-click Valt.app and select 'Open' (first launch)"
+else
+    echo "Error: DMG creation failed"
+    exit 1
+fi

--- a/scripts/package-macos.sh
+++ b/scripts/package-macos.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+set -e
+
+echo "=== Valt macOS Packaging Script ==="
+echo ""
+
+# 1. Clean previous local outputs
+echo "[1/11] Cleaning previous outputs..."
+rm -rf publish/
+rm -rf Valt.app
+rm -f Valt-macos-arm64.dmg
+echo "Cleaned publish/, Valt.app, Valt-macos-arm64.dmg"
+echo ""
+
+# 2. Publish the Avalonia/.NET app for macOS Apple Silicon
+echo "[2/11] Publishing app for macOS arm64..."
+dotnet publish src/Valt.UI/Valt.UI.csproj -c Release -r osx-arm64 --self-contained true -p:PublishSingleFile=false -p:PublishTrimmed=false -o publish/macos-arm64/
+echo "Publish complete."
+echo ""
+
+# 3. Create a proper macOS app bundle structure
+echo "[3/11] Creating .app bundle structure..."
+mkdir -p Valt.app/Contents/MacOS
+mkdir -p Valt.app/Contents/Resources
+echo "Created Valt.app/Contents/{MacOS,Resources}"
+echo ""
+
+# 4. Copy all published files into Valt.app/Contents/MacOS/
+echo "[4/11] Copying published files..."
+cp -R publish/macos-arm64/* Valt.app/Contents/MacOS/
+echo "Copied published files to Valt.app/Contents/MacOS/"
+echo ""
+
+# 5. Copy Info.plist
+echo "[5/11] Copying Info.plist..."
+cp src/Valt.UI/Info.plist Valt.app/Contents/Info.plist
+echo "Copied src/Valt.UI/Info.plist to Valt.app/Contents/Info.plist"
+echo ""
+
+# 6. Copy the icon if available
+echo "[6/11] Copying icon resources..."
+if [ -f src/Valt.UI/Assets/valt-logo.ico ]; then
+    cp src/Valt.UI/Assets/valt-logo.ico Valt.app/Contents/Resources/
+    echo "Copied valt-logo.ico to Resources/"
+else
+    echo "Warning: valt-logo.ico not found, skipping icon copy"
+fi
+
+# Also copy PNG if available
+if [ -f src/Valt.UI/Assets/valt-logo.png ]; then
+    cp src/Valt.UI/Assets/valt-logo.png Valt.app/Contents/Resources/
+    echo "Copied valt-logo.png to Resources/"
+fi
+echo ""
+
+# 7. Make the executable file executable
+echo "[7/11] Setting executable permissions..."
+chmod +x Valt.app/Contents/MacOS/Valt
+echo "Made Valt executable"
+echo ""
+
+# 8. Remove quarantine attributes
+echo "[8/11] Removing quarantine attributes..."
+xattr -cr Valt.app || true
+echo "Removed extended attributes"
+echo ""
+
+# 9. Sign locally with ad-hoc codesign using entitlements
+echo "[9/11] Codesigning with ad-hoc signature..."
+codesign --deep --force --sign - --entitlements src/Valt.UI/entitlements.plist Valt.app
+echo "Codesign complete"
+echo ""
+
+# 10. Verify codesign if possible
+echo "[10/11] Verifying codesign..."
+codesign --verify --verbose Valt.app 2>&1 || echo "Warning: codesign verification had issues"
+echo ""
+
+# 11. Print final commands
+echo "[11/11] Packaging complete!"
+echo ""
+echo "=== Final Commands ==="
+echo "Open the app:"
+echo "  open Valt.app"
+echo ""
+echo "Run from terminal:"
+echo "  ./Valt.app/Contents/MacOS/Valt"
+echo ""
+echo "Create DMG for distribution (optional):"
+echo "  hdiutil create -volname Valt -srcfolder Valt.app -ov -format UDZO Valt-macos-arm64.dmg"
+echo ""
+echo "=== Done ==="

--- a/src/Valt.UI/Info.plist
+++ b/src/Valt.UI/Info.plist
@@ -9,9 +9,9 @@
     <key>CFBundleIdentifier</key>
     <string>com.doomlabs.valt</string>
     <key>CFBundleVersion</key>
-    <string>VERSION_PLACEHOLDER</string>
+    <string>0.2.10.2</string>
     <key>CFBundleShortVersionString</key>
-    <string>VERSION_PLACEHOLDER</string>
+    <string>0.1.0</string>
     <key>CFBundleExecutable</key>
     <string>Valt</string>
     <key>CFBundleIconFile</key>

--- a/src/Valt.UI/Valt.UI.csproj
+++ b/src/Valt.UI/Valt.UI.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <OutputType>WinExe</OutputType>
+        <OutputType>Exe</OutputType>
         <TargetFramework>net10.0</TargetFramework>
+    <RuntimeIdentifier>osx-arm64</RuntimeIdentifier>
+    <PublishTrimmed>false</PublishTrimmed>
         <Nullable>enable</Nullable>
         <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
         <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/src/Valt.UI/entitlements.plist
+++ b/src/Valt.UI/entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

This PR adds local macOS packaging support for Valt.

It allows macOS users and contributors to build a working `Valt.app` bundle and generate a drag-and-drop `.dmg` installer locally.

## What changed

- Added macOS app bundle configuration through `Info.plist`
- Added macOS entitlements required for local Avalonia/.NET execution
- Updated the UI project configuration for macOS execution
- Added `scripts/package-macos.sh` to generate `Valt.app`
- Added `scripts/create-dmg.sh` to generate `Valt-macos-arm64.dmg`
- Updated `.gitignore` to exclude generated macOS artifacts
- Added README instructions for macOS packaging

## Why

Previously, the app could build on macOS, but it did not launch properly as a macOS application. Running the generated executable directly could result in the process being killed or crashing.

This PR makes the macOS app bundle reproducible and allows users to generate a DMG installer locally.

## Tested

Tested on macOS Apple Silicon.

- `dotnet build` succeeds
- `./scripts/package-macos.sh` creates `Valt.app`
- `./scripts/create-dmg.sh` creates `Valt-macos-arm64.dmg`
- DMG opens correctly
- Dragging `Valt.app` to `/Applications` works
- App launches from `/Applications`

## Notes

This PR uses ad-hoc codesigning for local development only.

For public distribution without Gatekeeper warnings, the app would still need to be signed with an Apple Developer ID certificate and notarized by Apple. That step is intentionally not included here.